### PR TITLE
New feature: RoboCaddie sends a STOP message to the motor when it is stopped

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 ## TODO list
 
 - ~~RoboCaddie is stopped at startup~~
+  - RoboCaddie sends a STOP message to the motor when it is stopped
+  - RoboCaddie transmits a message to the motor every 30ms
 - RoboCaddie goes forward when it receives a forward command
 - RoboCaddie goes backward when it receives a backward command
 - RoboCaddie goes left when it receives a left command

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 ## TODO list
 
 - ~~RoboCaddie is stopped at startup~~
-  - RoboCaddie sends a STOP message to the motor when it is stopped
+  - ~~RoboCaddie sends a STOP message to the motor when it is stopped~~
   - RoboCaddie transmits a message to the motor every 30ms
 - RoboCaddie goes forward when it receives a forward command
 - RoboCaddie goes backward when it receives a backward command

--- a/lib/RoboCaddie/src/RoboCaddie.cpp
+++ b/lib/RoboCaddie/src/RoboCaddie.cpp
@@ -6,4 +6,4 @@ RoboCaddie::~RoboCaddie() {}
 
 const int RoboCaddie::getStatus() { return STOP; }
 
-void RoboCaddie::transmission(UART &uart) {}
+void RoboCaddie::transmission(UART &uart) { uart.transmit({}, 0); }

--- a/lib/RoboCaddie/src/RoboCaddie.cpp
+++ b/lib/RoboCaddie/src/RoboCaddie.cpp
@@ -6,4 +6,8 @@ RoboCaddie::~RoboCaddie() {}
 
 const int RoboCaddie::getStatus() { return STOP; }
 
-void RoboCaddie::transmission(UART &uart) { uart.transmit({}, 0); }
+void RoboCaddie::transmission(UART &uart) {
+  std::vector<uint8_t> stopMsg = {0x04, 0x01, 0x0A, 0x57, 0x0E, 0x00, 0x00,
+                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90};
+  uart.transmit(stopMsg.data(), stopMsg.size());
+}

--- a/lib/RoboCaddie/src/RoboCaddie.cpp
+++ b/lib/RoboCaddie/src/RoboCaddie.cpp
@@ -1,12 +1,12 @@
 #include "RoboCaddie.h"
 
-RoboCaddie::RoboCaddie() {}
+RoboCaddie::RoboCaddie(UART &uart) : uart(uart) {}
 
 RoboCaddie::~RoboCaddie() {}
 
 const int RoboCaddie::getStatus() { return STOP; }
 
-void RoboCaddie::transmission(UART &uart) {
+void RoboCaddie::transmission() {
   std::vector<uint8_t> stopMsg = {0x04, 0x01, 0x0A, 0x57, 0x0E, 0x00, 0x00,
                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90};
   uart.transmit(stopMsg.data(), stopMsg.size());

--- a/lib/RoboCaddie/src/RoboCaddie.cpp
+++ b/lib/RoboCaddie/src/RoboCaddie.cpp
@@ -5,3 +5,5 @@ RoboCaddie::RoboCaddie() {}
 RoboCaddie::~RoboCaddie() {}
 
 const int RoboCaddie::getStatus() { return STOP; }
+
+void RoboCaddie::transmission(UART &uart) {}

--- a/lib/RoboCaddie/src/RoboCaddie.h
+++ b/lib/RoboCaddie/src/RoboCaddie.h
@@ -1,6 +1,8 @@
 #ifndef __ROBOCADDIE_H
 #define __ROBOCADDIE_H
 
+#include <UART.h>
+
 class RoboCaddie {
 private:
 public:
@@ -9,6 +11,7 @@ public:
   RoboCaddie();
   ~RoboCaddie();
   const int getStatus();
+  void transmission(UART &);
 };
 
 #endif

--- a/lib/RoboCaddie/src/RoboCaddie.h
+++ b/lib/RoboCaddie/src/RoboCaddie.h
@@ -5,13 +5,15 @@
 
 class RoboCaddie {
 private:
+  UART &uart;
+
 public:
   static const int STOP = 0;
 
-  RoboCaddie();
+  RoboCaddie(UART &);
   ~RoboCaddie();
   const int getStatus();
-  void transmission(UART &);
+  void transmission();
 };
 
 #endif

--- a/lib/RoboCaddie/src/UART.h
+++ b/lib/RoboCaddie/src/UART.h
@@ -19,9 +19,8 @@ public:
   SpyUART() : UART() {}
 
   const int transmit(const uint8_t *message, int length) {
-    lastSentMessage = {0x04, 0x01, 0x0A, 0x57, 0x0E, 0x00, 0x00,
-                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90};
-    return 14;
+    lastSentMessage.assign(message, message + length);
+    return length;
   }
 
   std::vector<uint8_t> getLastSentMessage() { return lastSentMessage; }

--- a/lib/RoboCaddie/src/UART.h
+++ b/lib/RoboCaddie/src/UART.h
@@ -1,0 +1,26 @@
+#ifndef __UART_H
+#define __UART_H
+
+#include <stdint.h>
+#include <vector>
+
+class UART {
+public:
+  UART() {}
+  ~UART() {}
+  virtual const int transmit(const uint8_t *message, int length) = 0;
+};
+
+class SpyUART : public UART {
+private:
+  std::vector<uint8_t> lastSentMessage = {};
+
+public:
+  SpyUART() : UART() {}
+
+  const int transmit(const uint8_t *message, int length) { return 0; }
+
+  std::vector<uint8_t> getLastSentMessage() { return {}; }
+};
+
+#endif

--- a/lib/RoboCaddie/src/UART.h
+++ b/lib/RoboCaddie/src/UART.h
@@ -13,10 +13,14 @@ public:
 
 class SpyUART : public UART {
 private:
-  std::vector<uint8_t> lastSentMessage = {};
+  std::vector<uint8_t> lastSentMessage;
+  const int MAX_UART_MESSAGE_LENGTH = 258;
 
 public:
-  SpyUART() : UART() {}
+  SpyUART() : UART() {
+    lastSentMessage.reserve(MAX_UART_MESSAGE_LENGTH);
+    lastSentMessage = {};
+  }
 
   const int transmit(const uint8_t *message, int length) {
     lastSentMessage.assign(message, message + length);

--- a/lib/RoboCaddie/src/UART.h
+++ b/lib/RoboCaddie/src/UART.h
@@ -18,9 +18,13 @@ private:
 public:
   SpyUART() : UART() {}
 
-  const int transmit(const uint8_t *message, int length) { return 0; }
+  const int transmit(const uint8_t *message, int length) {
+    lastSentMessage = {0x04, 0x01, 0x0A, 0x57, 0x0E, 0x00, 0x00,
+                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90};
+    return 14;
+  }
 
-  std::vector<uint8_t> getLastSentMessage() { return {}; }
+  std::vector<uint8_t> getLastSentMessage() { return lastSentMessage; }
 };
 
 #endif

--- a/test/Test_RoboCaddie.cpp
+++ b/test/Test_RoboCaddie.cpp
@@ -9,10 +9,55 @@ void test_robocaddie_is_stopped_on_startup() {
   TEST_ASSERT_EQUAL(RoboCaddie::STOP, robocaddie.getStatus());
 }
 
+void test_a_STOP_message_is_sent_to_the_motor_when_robocaddie_status_is_STOP() {
+  const uint8_t PROTOCOL_MSG2_SOM = 0x04;  // PROTOCOL_SOM_NOACK
+  const uint8_t PROTOCOL_MSG2_CI = 0x01;   // Continuity Counter
+  const uint8_t PROTOCOL_MSG2_LEN = 0x0A;  // Len of bytes to follow,
+                                           // NOT including CS
+                                           // (CheckSum)
+  const uint8_t PROTOCOL_MSG2_CMD = 0x57;  // PROTOCOL_CMD_WRITEVAL ('W')
+  const uint8_t PROTOCOL_MSG2_CODE = 0x0E; // setPointPWM
+
+  // PWM Values on little endian. Examples:
+  // (0x00 0x00 0x00 0x00 => PWM = 0)
+  // (0x64 0x00 0x00 0x00 => PWM = 100)
+  const uint8_t PROTOCOL_MSG2_RIGHT_WHEEL1 = 0x00;
+  const uint8_t PROTOCOL_MSG2_RIGHT_WHEEL2 = 0x00;
+  const uint8_t PROTOCOL_MSG2_RIGHT_WHEEL3 = 0x00;
+  const uint8_t PROTOCOL_MSG2_RIGHT_WHEEL4 = 0x00;
+  const uint8_t PROTOCOL_MSG2_LEFT_WHEEL1 = 0x00;
+  const uint8_t PROTOCOL_MSG2_LEFT_WHEEL2 = 0x00;
+  const uint8_t PROTOCOL_MSG2_LEFT_WHEEL3 = 0x00;
+  const uint8_t PROTOCOL_MSG2_LEFT_WHEEL4 = 0x00;
+  const uint8_t PROTOCOL_MSG2_CS = 0x90; // CheckSum (From CI to WHEEL2)
+
+  std::vector<uint8_t> stop_msg = {
+      PROTOCOL_MSG2_SOM,          PROTOCOL_MSG2_CI,
+      PROTOCOL_MSG2_LEN,          PROTOCOL_MSG2_CMD,
+      PROTOCOL_MSG2_CODE,         PROTOCOL_MSG2_RIGHT_WHEEL1,
+      PROTOCOL_MSG2_RIGHT_WHEEL2, PROTOCOL_MSG2_RIGHT_WHEEL3,
+      PROTOCOL_MSG2_RIGHT_WHEEL4, PROTOCOL_MSG2_LEFT_WHEEL1,
+      PROTOCOL_MSG2_LEFT_WHEEL2,  PROTOCOL_MSG2_LEFT_WHEEL3,
+      PROTOCOL_MSG2_LEFT_WHEEL4,  PROTOCOL_MSG2_CS};
+
+  RoboCaddie robocaddie;
+  SpyUART uart;
+
+  // Precondition: no message sent yet on initialization
+  TEST_ASSERT_NULL(uart.getLastSentMessage().data());
+
+  robocaddie.transmission(uart);
+
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(
+      stop_msg.data(), uart.getLastSentMessage().data(), stop_msg.size());
+}
+
 int main(int argc, char **argv) {
   UNITY_BEGIN();
 
   RUN_TEST(test_robocaddie_is_stopped_on_startup);
+  RUN_TEST(
+      test_a_STOP_message_is_sent_to_the_motor_when_robocaddie_status_is_STOP);
 
   UNITY_END();
 }

--- a/test/Test_RoboCaddie.cpp
+++ b/test/Test_RoboCaddie.cpp
@@ -32,7 +32,7 @@ void test_a_STOP_message_is_sent_to_the_motor_when_robocaddie_status_is_STOP() {
   const uint8_t PROTOCOL_MSG2_LEFT_WHEEL4 = 0x00;
   const uint8_t PROTOCOL_MSG2_CS = 0x90; // CheckSum (From CI to WHEEL2)
 
-  std::vector<uint8_t> stop_msg = {
+  const std::vector<uint8_t> stop_msg = {
       PROTOCOL_MSG2_SOM,          PROTOCOL_MSG2_CI,
       PROTOCOL_MSG2_LEN,          PROTOCOL_MSG2_CMD,
       PROTOCOL_MSG2_CODE,         PROTOCOL_MSG2_RIGHT_WHEEL1,

--- a/test/Test_RoboCaddie.cpp
+++ b/test/Test_RoboCaddie.cpp
@@ -4,7 +4,8 @@
 #include <unity.h>
 
 void test_robocaddie_is_stopped_on_startup() {
-  RoboCaddie robocaddie;
+  SpyUART uart;
+  RoboCaddie robocaddie(uart);
 
   TEST_ASSERT_EQUAL(RoboCaddie::STOP, robocaddie.getStatus());
 }
@@ -40,13 +41,13 @@ void test_a_STOP_message_is_sent_to_the_motor_when_robocaddie_status_is_STOP() {
       PROTOCOL_MSG2_LEFT_WHEEL2,  PROTOCOL_MSG2_LEFT_WHEEL3,
       PROTOCOL_MSG2_LEFT_WHEEL4,  PROTOCOL_MSG2_CS};
 
-  RoboCaddie robocaddie;
   SpyUART uart;
+  RoboCaddie robocaddie(uart);
 
   // Precondition: no message sent yet on initialization
   TEST_ASSERT_NULL(uart.getLastSentMessage().data());
 
-  robocaddie.transmission(uart);
+  robocaddie.transmission();
 
   TEST_ASSERT_EQUAL_UINT8_ARRAY(
       stop_msg.data(), uart.getLastSentMessage().data(), stop_msg.size());


### PR DESCRIPTION
It uses UART messages to communicate to the motors.
A SpyUART is implemented to decouple uart hardware and testing purposes.
UART messages are defined in: https://github.com/bipropellant/bipropellant-protocol/wiki/Protocol-Defn
Our hardware uses PROTOCOL_MSG2 version.