### PR TITLE
feat: InputController support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,3 +20,4 @@
 - RoboCaddie stops when not receives any command for 500ms
 - RoboCaddie goes forward left if it is going forward and it receives a left command
 - RoboCaddie goes forward left if it is going left and it receives a forward command
+- InputCommander

--- a/TODO.md
+++ b/TODO.md
@@ -17,10 +17,10 @@
 - ~~RoboCaddie goes {direction} when it receives a {direction} command~~
 - ~~RoboCaddie stops when it receives a stop command~~
 - ~~Disallow invalid commands and statuses~~
-- RoboCaddie stops on disconnect
+- ~~RoboCaddie stops on disconnect~~
 - RoboCaddie goes forward left if it is going forward and it receives a left command
 - RoboCaddie goes forward left if it is going left and it receives a forward command
-- InputController interface (ACGAMR1Controller/...)
+- ~~InputController interface (ACGAMR1Controller/...)~~
 - Output feedback interface (Serial/Display...) to show Command/Status/PWM
 - Output feedback: show hoverboard speed feedback
 - Output feedback: show hoverboard battery voltage feedback

--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,20 @@
 - ~~RoboCaddie goes {direction} when it receives a {direction} command~~
 - ~~RoboCaddie stops when it receives a stop command~~
 - ~~Disallow invalid commands and statuses~~
-- RoboCaddie stops when not receives any command for 500ms
+- RoboCaddie stops on disconnect
 - RoboCaddie goes forward left if it is going forward and it receives a left command
 - RoboCaddie goes forward left if it is going left and it receives a forward command
-- InputCommander
+- InputController interface (ACGAMR1Controller/...)
+- Output feedback interface (Serial/Display...) to show Command/Status/PWM
+- Output feedback: show hoverboard speed feedback
+- Output feedback: show hoverboard battery voltage feedback
+- Output feedback: show InputController battery voltage feedback
+- Gears support
+- Smooth aceleration (incremental PWM)
+
+
+## TECH debt
+
+- Avoid volatile static Command inputControllerCommand: https://github.com/arduino-libraries/ArduinoBLE/issues/182 
+- Refactor: Extract transmission to MotorDriver interface
+- ACGAMR1 controller codes documentation

--- a/lib/RoboCaddie/src/Command.h
+++ b/lib/RoboCaddie/src/Command.h
@@ -1,0 +1,6 @@
+#ifndef __COMMAND_H
+#define __COMMAND_H
+
+enum class Command { STOP = 0, FORWARD = 1, BACKWARD = 2, RIGHT = 3, LEFT = 4 };
+
+#endif

--- a/lib/RoboCaddie/src/InputController.h
+++ b/lib/RoboCaddie/src/InputController.h
@@ -1,0 +1,38 @@
+#ifndef __INPUTCONTROLLER_H
+#define __INPUTCONTROLLER_H
+
+class InputController {
+public:
+  InputController() {}
+  virtual ~InputController() {}
+  virtual void init() = 0;
+  virtual void connect() = 0;
+  virtual bool isConnected() = 0;
+  virtual Command readCommand() = 0;
+};
+
+class DummyController : public InputController {
+public:
+  DummyController(TimeService &time) : InputController(), time(time) {}
+
+  void init() {}
+  void connect() {}
+  bool isConnected() { return true; }
+
+  Command readCommand() {
+    if (time.isTick(3000)) {
+      if (command == Command::STOP) {
+        command = Command::FORWARD;
+      } else {
+        command = Command::STOP;
+      }
+    }
+    return command;
+  }
+
+private:
+  Command command = Command::STOP;
+  TimeService &time;
+};
+
+#endif

--- a/lib/RoboCaddie/src/InputController.h
+++ b/lib/RoboCaddie/src/InputController.h
@@ -35,4 +35,142 @@ private:
   TimeService &time;
 };
 
+#ifdef ARDUINO
+
+#include <ArduinoBLE.h>
+
+// TODO: https://github.com/arduino-libraries/ArduinoBLE/issues/182
+volatile static Command inputControllerCommand = Command::STOP;
+
+class ACGAMR1Controller : public InputController {
+public:
+  ACGAMR1Controller() : InputController() {}
+
+  void init() {
+    Serial.begin(115200);
+    if (!BLE.begin()) {
+      Serial.println("BLE init failed!");
+      return;
+    }
+    BLE.setSupervisionTimeout(0x000A);
+    BLE.setEventHandler(BLEDisconnected, blePeripheralDisconnectHandler);
+    Serial.println("BLE scanning...");
+    BLE.scanForName(deviceName);
+  }
+
+  Command readCommand() {
+    BLE.poll();
+    return inputControllerCommand;
+  }
+
+  void connect() {
+    peripheral = BLE.available();
+    if (peripheral && peripheral.localName() == deviceName) {
+      BLE.stopScan();
+      if (!peripheral.connect()) {
+        Serial.println("Peripheral connect failed");
+        return;
+      }
+
+      if (!peripheral.discoverAttributes()) {
+        Serial.println("Attribute discovery failed");
+        peripheral.disconnect();
+        return;
+      }
+
+      if (!peripheral.discoverService(hidServiceId)) {
+        Serial.println("0x1812 disc failed");
+        peripheral.disconnect();
+        return;
+      }
+
+      BLEService hidService = peripheral.service(hidServiceId);
+
+      // There are multiple 2A4D characteristics
+      // We need to subscribe to all of them
+      int iCount = hidService.characteristicCount();
+      for (int i = 0; i < iCount; i++) {
+        BLECharacteristic bc = hidService.characteristic(i);
+        if (strcasecmp(bc.uuid(), hidServiceReportId) == 0) {
+          bc.subscribe();
+          bc.setEventHandler(BLEWritten, HIDReportWritten);
+        }
+      }
+    }
+  }
+
+  bool isConnected() { return peripheral.connected(); }
+
+  static Command parseHIDReport(const uint8_t *reportData, size_t length) {
+    if (length != 2) {
+      return Command::STOP;
+    }
+
+    const uint16_t BUTTON_LEFT = 0x100;
+    const uint16_t BUTTON_RIGHT = 0x200;
+    const uint16_t BUTTON_UP = 0x400;
+    const uint16_t BUTTON_DOWN = 0x800;
+
+    // Extract buttons and axis information
+    uint16_t buttonsState = reportData[0];
+    uint8_t yAxis = reportData[1] & 0xC0;
+    uint8_t xAxis = reportData[1] & 0x30;
+
+    if (yAxis == 0x00) {
+      buttonsState |= BUTTON_UP;
+    } else if (yAxis == 0x80) {
+      buttonsState |= BUTTON_DOWN;
+    }
+
+    if (xAxis == 0x00) {
+      buttonsState |= BUTTON_LEFT;
+    } else if (xAxis == 0x20) {
+      buttonsState |= BUTTON_RIGHT;
+    }
+
+    Command command = Command::STOP;
+
+    if (buttonsState == BUTTON_UP) {
+      command = Command::FORWARD;
+    }
+    if (buttonsState == BUTTON_DOWN) {
+      command = Command::BACKWARD;
+    }
+    if (buttonsState == BUTTON_LEFT) {
+      command = Command::LEFT;
+    }
+    if (buttonsState == BUTTON_RIGHT) {
+      command = Command::RIGHT;
+    }
+
+    inputControllerCommand = command;
+
+    return command;
+  }
+
+private:
+  BLEDevice peripheral;
+  const char *deviceName = "ACGAM R1          ";
+  const char *hidServiceId = "1812";
+  const char *hidServiceReportId = "2A4D";
+
+  static void blePeripheralDisconnectHandler(BLEDevice central) {
+    Serial.println("blePeripheralDisconnectHandler");
+    Serial.println("BLE scanning...");
+    BLE.scanForName("ACGAM R1          ");
+  }
+
+  static void HIDReportWritten(BLEDevice device,
+                               BLECharacteristic characteristic) {
+    uint8_t lenght;
+    uint8_t reportData[2];
+
+    lenght = characteristic.readValue(reportData, sizeof(reportData));
+
+    inputControllerCommand = parseHIDReport(reportData, lenght);
+  }
+};
+
+#endif
+
 #endif

--- a/lib/RoboCaddie/src/RoboCaddie.cpp
+++ b/lib/RoboCaddie/src/RoboCaddie.cpp
@@ -20,8 +20,6 @@ RoboCaddie::~RoboCaddie() {
   }
 }
 
-RoboCaddie::Status RoboCaddie::getStatus() { return status; }
-
 void RoboCaddie::setStatus(const Command command) {
   static const std::map<Command, Status> statusValues = {
       {Command::STOP, Status::STOP},

--- a/lib/RoboCaddie/src/RoboCaddie.cpp
+++ b/lib/RoboCaddie/src/RoboCaddie.cpp
@@ -46,7 +46,7 @@ void RoboCaddie::init() {
 
 void RoboCaddie::transmission() {
   // PWMValues: {status, {power, steer}}
-  static const std::map<Status, std::pair<uint16_t, uint16_t>> pwmValues = {
+  static const std::map<Status, std::pair<int16_t, int16_t>> pwmValues = {
       {Status::STOP, {0, 0}},
       {Status::FORWARD, {100, 0}},
       {Status::BACKWARD, {-100, 0}},

--- a/lib/RoboCaddie/src/RoboCaddie.cpp
+++ b/lib/RoboCaddie/src/RoboCaddie.cpp
@@ -20,7 +20,7 @@ RoboCaddie::~RoboCaddie() {
   }
 }
 
-void RoboCaddie::setStatus(const Command command) {
+void RoboCaddie::execute(const Command command) {
   static const std::map<Command, Status> statusValues = {
       {Command::STOP, Status::STOP},
       {Command::FORWARD, Status::FORWARD},
@@ -55,6 +55,11 @@ void RoboCaddie::transmission() {
   } else {
     hover.sendPWM(0, 0, PROTOCOL_SOM_NOACK);
   }
+}
+
+void RoboCaddie::run(const Command command) {
+  execute(command);
+  run();
 }
 
 void RoboCaddie::run() {

--- a/lib/RoboCaddie/src/RoboCaddie.h
+++ b/lib/RoboCaddie/src/RoboCaddie.h
@@ -28,7 +28,6 @@ public:
   Status getStatus();
   void setStatus(const Command command);
   void init();
-  void transmission();
   void run();
 
 private:
@@ -38,6 +37,7 @@ private:
   Status status = Status::STOP;
   const uint8_t TRANSMISSION_TICKER_INTERVAL_IN_MILLISECONDS = 30;
 
+  void transmission();
   int UARTWrapper(unsigned char *data, int len);
   friend int UARTWrapperStatic(unsigned char *data, int len);
 };

--- a/lib/RoboCaddie/src/RoboCaddie.h
+++ b/lib/RoboCaddie/src/RoboCaddie.h
@@ -25,7 +25,6 @@ public:
 
   RoboCaddie(RoboCaddieUART::UART &, TimeService &);
   ~RoboCaddie();
-  Status getStatus();
   void setStatus(const Command command);
   void init();
   void run();

--- a/lib/RoboCaddie/src/RoboCaddie.h
+++ b/lib/RoboCaddie/src/RoboCaddie.h
@@ -6,6 +6,9 @@
 #include "TimeService.h"
 #include "UART.h"
 
+#include "Command.h"
+#include "InputController.h"
+
 class RoboCaddie {
 public:
   enum class Status {
@@ -15,23 +18,16 @@ public:
     RIGHT = 3,
     LEFT = 4
   };
-  enum class Command {
-    STOP = 0,
-    FORWARD = 1,
-    BACKWARD = 2,
-    RIGHT = 3,
-    LEFT = 4
-  };
 
-  RoboCaddie(RoboCaddieUART::UART &, TimeService &);
+  RoboCaddie(RoboCaddieUART::UART &, TimeService &, InputController &);
   ~RoboCaddie();
   void init();
   void run();
-  void run(const Command command);
 
 private:
   RoboCaddieUART::UART &uart;
   TimeService &time;
+  InputController &inputController;
   HoverboardAPI hover;
   Status status = Status::STOP;
   const uint8_t TRANSMISSION_TICKER_INTERVAL_IN_MILLISECONDS = 30;

--- a/lib/RoboCaddie/src/RoboCaddie.h
+++ b/lib/RoboCaddie/src/RoboCaddie.h
@@ -25,9 +25,9 @@ public:
 
   RoboCaddie(RoboCaddieUART::UART &, TimeService &);
   ~RoboCaddie();
-  void setStatus(const Command command);
   void init();
   void run();
+  void run(const Command command);
 
 private:
   RoboCaddieUART::UART &uart;
@@ -36,6 +36,7 @@ private:
   Status status = Status::STOP;
   const uint8_t TRANSMISSION_TICKER_INTERVAL_IN_MILLISECONDS = 30;
 
+  void execute(const Command command);
   void transmission();
   int UARTWrapper(unsigned char *data, int len);
   friend int UARTWrapperStatic(unsigned char *data, int len);

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,6 +23,7 @@ build_flags = -DGTEST_OS_NRF52
 test_framework = googletest
 test_ignore = test_runner_native
 extra_scripts = test/wait_for_restart.py
+lib_deps = arduino-libraries/ArduinoBLE@^1.3.7
 
 [env:nano33ble-renode]
 extends = env:nano33ble
@@ -39,3 +40,4 @@ test_testing_command =
 	-e showAnalyzer uart0
 	-e sysbus LoadELF @${platformio.build_dir}/${this.__env__}/firmware.elf
 	-e start
+lib_deps = arduino-libraries/ArduinoBLE@^1.3.7

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,8 @@ ArduinoTimeService timeservice;
 ArduinoTimeService arduinoTimeService;
 RoboCaddie robocaddie(uart, timeservice);
 
+RoboCaddie::Command command = RoboCaddie::Command::STOP
+
 void setup() {
   delay(2000);
   robocaddie.init();
@@ -17,11 +19,12 @@ void setup() {
 
 void loop() {
   if (arduinoTimeService.isTick(3000)) {
-    if (robocaddie.getStatus() == 0) {
-      robocaddie.setStatus(RoboCaddie::FORWARD);
+    if (command == RoboCaddie::Command::STOP) {
+      command = RoboCaddie::Command::FORWARD;
     } else {
-      robocaddie.setStatus(RoboCaddie::STOP);
+      command = RoboCaddie::Command::STOP;
     }
+    robocaddie.setStatus(command);
   }
   robocaddie.run();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,9 +24,8 @@ void loop() {
     } else {
       command = RoboCaddie::Command::STOP;
     }
-    robocaddie.setStatus(command);
   }
-  robocaddie.run();
+  robocaddie.run(command);
 }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,11 @@
 ArduinoSerial1UART uart;
 ArduinoTimeService timeservice;
 ArduinoTimeService timeserviceInputController;
+#ifdef DUMMYCONTROLLER
 DummyController inputController(timeserviceInputController);
+#else
+ACGAMR1Controller inputController;
+#endif
 RoboCaddie robocaddie(uart, timeservice, inputController);
 
 void setup() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,10 +6,9 @@
 
 ArduinoSerial1UART uart;
 ArduinoTimeService timeservice;
-ArduinoTimeService arduinoTimeService;
-RoboCaddie robocaddie(uart, timeservice);
-
-RoboCaddie::Command command = RoboCaddie::Command::STOP;
+ArduinoTimeService timeserviceInputController;
+DummyController inputController(timeserviceInputController);
+RoboCaddie robocaddie(uart, timeservice, inputController);
 
 void setup() {
   delay(2000);
@@ -17,16 +16,8 @@ void setup() {
   delay(1000);
 }
 
-void loop() {
-  if (arduinoTimeService.isTick(3000)) {
-    if (command == RoboCaddie::Command::STOP) {
-      command = RoboCaddie::Command::FORWARD;
-    } else {
-      command = RoboCaddie::Command::STOP;
-    }
-  }
-  robocaddie.run(command);
-}
+void loop() { robocaddie.run(); }
+
 #endif
 
 #ifndef ARDUINO

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@ ArduinoTimeService timeservice;
 ArduinoTimeService arduinoTimeService;
 RoboCaddie robocaddie(uart, timeservice);
 
-RoboCaddie::Command command = RoboCaddie::Command::STOP
+RoboCaddie::Command command = RoboCaddie::Command::STOP;
 
 void setup() {
   delay(2000);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,8 +6,8 @@
 
 ArduinoSerial1UART uart;
 ArduinoTimeService timeservice;
-ArduinoTimeService timeserviceInputController;
 #ifdef DUMMYCONTROLLER
+ArduinoTimeService timeserviceInputController;
 DummyController inputController(timeserviceInputController);
 #else
 ACGAMR1Controller inputController;

--- a/test/RoboCaddie/InputControllerTests.h
+++ b/test/RoboCaddie/InputControllerTests.h
@@ -1,0 +1,39 @@
+#ifdef UNIT_TEST
+
+using ::testing::Return;
+
+class MockDummyControllerTimeService : public TimeService {
+public:
+  MOCK_METHOD(bool, isTick, (const uint16_t milliseconds), (override));
+};
+
+class DummyControllerFixture : public ::testing::Test {
+protected:
+  MockDummyControllerTimeService time;
+  DummyController inputController;
+
+  DummyControllerFixture() : inputController(time) {}
+};
+
+TEST_F(DummyControllerFixture, InitialStateIsStopped) {
+  EXPECT_EQ(inputController.readCommand(), Command::STOP);
+}
+
+TEST_F(DummyControllerFixture, CommandAlternatesBetweenStopAndForward) {
+  EXPECT_CALL(time, isTick(3000)).WillOnce(Return(true));
+  EXPECT_EQ(inputController.readCommand(), Command::FORWARD);
+
+  EXPECT_CALL(time, isTick(3000)).WillOnce(Return(true));
+  EXPECT_EQ(inputController.readCommand(), Command::STOP);
+}
+
+TEST_F(DummyControllerFixture, DoesNotChangeCommandWithoutTick) {
+  EXPECT_CALL(time, isTick(3000)).WillRepeatedly(Return(false));
+
+  Command firstCommand = inputController.readCommand();
+  Command secondCommand = inputController.readCommand();
+
+  EXPECT_EQ(firstCommand, secondCommand);
+}
+
+#endif

--- a/test/RoboCaddie/InputControllerTests.h
+++ b/test/RoboCaddie/InputControllerTests.h
@@ -37,7 +37,6 @@ TEST_F(DummyControllerFixture, DoesNotChangeCommandWithoutTick) {
 }
 
 #ifdef ARDUINO
-#include <iostream>
 
 class ACGAMR1ControllerFixture : public ::testing::Test {
 protected:

--- a/test/RoboCaddie/InputControllerTests.h
+++ b/test/RoboCaddie/InputControllerTests.h
@@ -36,4 +36,63 @@ TEST_F(DummyControllerFixture, DoesNotChangeCommandWithoutTick) {
   EXPECT_EQ(firstCommand, secondCommand);
 }
 
+#ifdef ARDUINO
+#include <iostream>
+
+class ACGAMR1ControllerFixture : public ::testing::Test {
+protected:
+  void testCommandInterpretation(const std::vector<uint8_t> &inputData,
+                                 Command expectedCommand,
+                                 const std::string &testCaseName) {
+    EXPECT_EQ(
+        ACGAMR1Controller::parseHIDReport(inputData.data(), inputData.size()),
+        expectedCommand)
+        << "Failed test case: " << static_cast<int>(inputData[0])
+        << static_cast<int>(inputData[1]) << testCaseName;
+  }
+};
+
+TEST_F(ACGAMR1ControllerFixture, InvalidInputHandling) {
+  testCommandInterpretation({}, Command::STOP, "Empty input");
+  testCommandInterpretation({0x00}, Command::STOP, "Single byte input");
+  testCommandInterpretation({0x00, 0x00, 0x00}, Command::STOP,
+                            "Oversized input");
+  testCommandInterpretation({0x00, 0x00}, Command::STOP,
+                            "Joystick up and left at same time, no buttons");
+}
+
+TEST_F(ACGAMR1ControllerFixture, ForwardCommand) {
+  testCommandInterpretation({0x00, 0x10}, Command::FORWARD, "Just joystick up");
+}
+
+TEST_F(ACGAMR1ControllerFixture, BackwardCommand) {
+  testCommandInterpretation({0x00, 0x90}, Command::BACKWARD,
+                            "Just joystick down");
+}
+
+TEST_F(ACGAMR1ControllerFixture, LeftCommand) {
+  testCommandInterpretation({0x00, 0x40}, Command::LEFT, "Just joystick left");
+}
+
+TEST_F(ACGAMR1ControllerFixture, RightCommand) {
+  testCommandInterpretation({0x00, 0x60}, Command::RIGHT,
+                            "Just joystick right");
+}
+
+TEST_F(ACGAMR1ControllerFixture, StopCommands) {
+  testCommandInterpretation({0x00, 0x50}, Command::STOP,
+                            "Centered joystick, no buttons");
+  testCommandInterpretation({0x01, 0x10}, Command::STOP, "Up but 1 button");
+  testCommandInterpretation({0x03, 0x90}, Command::STOP, "Down but 2 button");
+  testCommandInterpretation({0x01, 0x40}, Command::STOP, "Left but 1 button");
+  testCommandInterpretation({0x07, 0x60}, Command::STOP, "Right but 3 Buttons");
+}
+
+TEST_F(ACGAMR1ControllerFixture, BoundaryInputTest) {
+  testCommandInterpretation({0xFF, 0xFF}, Command::STOP,
+                            "Maximum Input Values");
+}
+
+#endif
+
 #endif

--- a/test/RoboCaddie/RoboCaddieTests.h
+++ b/test/RoboCaddie/RoboCaddieTests.h
@@ -22,6 +22,7 @@ protected:
 
   RoboCaddieFixture() : robocaddie(uart, time) {}
 };
+
 TEST_F(RoboCaddieFixture, RoboCaddieIsStoppedOnStartup) {
   EXPECT_EQ(RoboCaddie::Status::STOP, robocaddie.getStatus());
 }
@@ -98,9 +99,10 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(RoboCaddieMessageFixture,
        AMessageIsSentToTheMotorWhenRoboCaddieStatusIsX) {
   EXPECT_CALL(uart, transmit(GetParam().expectedMessage)).Times(1);
+  EXPECT_CALL(time, isTick(_)).WillOnce(Return(true));
 
   robocaddie.setStatus(GetParam().command);
-  robocaddie.transmission();
+  robocaddie.run();
 }
 
 TEST_F(RoboCaddieFixture,
@@ -160,10 +162,14 @@ TEST_F(RoboCaddieFixture, ConsecutiveMessagesIncreaseCIAndDecreaseCSvalues) {
   EXPECT_CALL(uart, transmit(stopMsg1)).Times(1);
   EXPECT_CALL(uart, transmit(stopMsg2)).Times(1);
   EXPECT_CALL(uart, transmit(stopMsg3)).Times(1);
+  EXPECT_CALL(time, isTick(_))
+      .WillOnce(Return(true))
+      .WillOnce(Return(true))
+      .WillOnce(Return(true));
 
-  robocaddie.transmission();
-  robocaddie.transmission();
-  robocaddie.transmission();
+  robocaddie.run();
+  robocaddie.run();
+  robocaddie.run();
 }
 
 #endif

--- a/test/RoboCaddie/RoboCaddieTests.h
+++ b/test/RoboCaddie/RoboCaddieTests.h
@@ -79,8 +79,7 @@ TEST_P(RoboCaddieMessageFixture,
   EXPECT_CALL(uart, transmit(GetParam().expectedMessage)).Times(1);
   EXPECT_CALL(time, isTick(_)).WillOnce(Return(true));
 
-  robocaddie.setStatus(GetParam().command);
-  robocaddie.run();
+  robocaddie.run(GetParam().command);
 }
 
 TEST_F(RoboCaddieFixture,

--- a/test/RoboCaddie/RoboCaddieTests.h
+++ b/test/RoboCaddie/RoboCaddieTests.h
@@ -24,40 +24,18 @@ protected:
 };
 
 TEST_F(RoboCaddieFixture, RoboCaddieIsStoppedOnStartup) {
-  EXPECT_EQ(RoboCaddie::Status::STOP, robocaddie.getStatus());
+  std::vector<uint8_t> stopMsg1 = {0x04, 0x01, 0x0A, 0x57, 0x0E, 0x00, 0x00,
+                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90};
+  EXPECT_CALL(uart, transmit(stopMsg1)).Times(1);
+  EXPECT_CALL(time, isTick(_)).WillOnce(Return(true));
+
+  robocaddie.run();
 }
 
 struct RoboCaddieStatusFixtureData {
   const RoboCaddie::Command command;
   const RoboCaddie::Status status;
 };
-
-class RoboCaddieStatusFixture
-    : public RoboCaddieFixture,
-      public testing::WithParamInterface<RoboCaddieStatusFixtureData> {};
-
-INSTANTIATE_TEST_SUITE_P(
-    RoboCaddieStatus, RoboCaddieStatusFixture,
-    testing::Values(RoboCaddieStatusFixtureData{RoboCaddie::Command::STOP,
-                                                RoboCaddie::Status::STOP},
-                    RoboCaddieStatusFixtureData{RoboCaddie::Command::FORWARD,
-                                                RoboCaddie::Status::FORWARD},
-                    RoboCaddieStatusFixtureData{RoboCaddie::Command::BACKWARD,
-                                                RoboCaddie::Status::BACKWARD},
-                    RoboCaddieStatusFixtureData{RoboCaddie::Command::RIGHT,
-                                                RoboCaddie::Status::RIGHT},
-                    RoboCaddieStatusFixtureData{RoboCaddie::Command::LEFT,
-                                                RoboCaddie::Status::LEFT},
-                    // Invalid command
-                    RoboCaddieStatusFixtureData{
-                        static_cast<RoboCaddie::Command>(127),
-                        RoboCaddie::Status::STOP}));
-
-TEST_P(RoboCaddieStatusFixture, RoboCaddieStatusIsXOnCommandX) {
-  robocaddie.setStatus(GetParam().command);
-
-  EXPECT_EQ(GetParam().status, robocaddie.getStatus());
-}
 
 struct RoboCaddieMessageFixtureData {
   const RoboCaddie::Command command;

--- a/test/test_runner_embedded/Test_Embedded.cpp
+++ b/test/test_runner_embedded/Test_Embedded.cpp
@@ -6,6 +6,8 @@
 #include "RoboCaddie.h"
 #include "RoboCaddie/RoboCaddieTests.h"
 
+#include "RoboCaddie/InputControllerTests.h"
+
 // Fix arduino/ArduinoCore-mbed issue:
 // https://github.com/platformio/platformio-core/issues/3980#issuecomment-1500895461
 #ifndef RENODE_ENVIRONMENT

--- a/test/test_runner_native/Test_Native.cpp
+++ b/test/test_runner_native/Test_Native.cpp
@@ -6,6 +6,8 @@
 #include "RoboCaddie.h"
 #include "RoboCaddie/RoboCaddieTests.h"
 
+#include "RoboCaddie/InputControllerTests.h"
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
 


### PR DESCRIPTION
Add support for Input Controllers. For now, 2 different controllers are supported:

* DummyController: A 3 second STOP-FORWARD loop to test in bare metal as an end2end test
* ACGAMR1Controller: A Bluetooth BLE remote control joystick